### PR TITLE
Makefile.uk: Add include/private to the list of include directories

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -97,7 +97,7 @@ LIBUUID_SRCS-y += $(LIBUUID_SRC)/uuid_time.c
 ################################################################################
 # Lib-specific Targets
 ################################################################################
-.PRECIOUS: $(LIBUUID_EXTRACTED)/%.h
+.PRECIOUS: $(LIBUUID_SRC)/%.h
 
 $(LIBUUID_BUILD)/include/public/%.h: $(LIBUUID_SRC)/%.h
 	$(call build_cmd,LN,libuuid,$@,\


### PR DESCRIPTION
There is an issue when building against [Musl](https://github.com/unikraft/lib-musl): `uuidP.h` is not found. This commit fixes it, by adding `include/private` to the `CINCLUDES-$(CONFIG_LIBUUID)`.

Not sure why the old version worked with newlib: `LIBUUID_CINCLUDES-y += -I$(LIBUUID_BUILD)/include/private`.