### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "libuuid"
+description := "A library for unique ID generation."
+website     := "https://sourceforge.net/projects/libuuid/"
+license     := "BSD-3-Clause"
+version     := 1.0.3 sha256:46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644 https://sourceforge.net/projects/libuuid/files/libuuid-1.0.3.tar.gz/download


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

