### PR TITLE
Correct libc dependency

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,7 +1,7 @@
 config LIBUUID
 	bool "libuuid - library for unique id generation"
 	default n
-	select LIBNEWLIBC
+	depends on HAVE_LIBC
 	select LIBPOSIX_USER
 	select LIBUKTIME
 


### PR DESCRIPTION
Previously libuuid would hard-select libnewlibc as it requires a libc.
This change eases this restriction into a dependency on any libc.