### PR TITLE
Makefile.uk: Fix subdirectory make rule

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -57,13 +57,13 @@ LIBUUID_SRC=$(LIBUUID_ORIGIN)/$(LIBUUID_SUBDIR)
 ################################################################################
 # Put public headers (uuid.h) in a public folder and export them globally. The
 # prepare step below takes care of populating the folder.
-$(call mk_sub_build_dir,libuuid/include/public)
+$(call mk_sub_libbuild_dir,libuuid,include/public)
 CINCLUDES-$(CONFIG_LIBUUID) += -I$(LIBUUID_BUILD)/include/public
 
 # Put private headers (the glue's config.h, and uuid's non-uuid.h headers)
 # in a private folder and export that only locally to libuuid. The prepare
 # step below takes care of populating the folder
-$(call mk_sub_build_dir,libuuid/include/private)
+$(call mk_sub_libbuild_dir,libuuid,include/private)
 LIBUUID_CINCLUDES-y += -I$(LIBUUID_BUILD)/include/private
 
 ################################################################################


### PR DESCRIPTION
Since commit unikraft/b8872a6 of the Unikraft core was merged,
`mk_sub_build_dir` will only create a top-level new directory, so using
it to create `libuuid/include/public` and `libuuid/include/private` is
not possible.
Use `mk_sub_libbuild_dir` instead, which can create a full path to a directory.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
